### PR TITLE
Fixed: HttpHelper.UrlEncode didn't encode long strings.

### DIFF
--- a/HttpHelper.cs.pp
+++ b/HttpHelper.cs.pp
@@ -1395,7 +1395,7 @@ namespace $rootnamespace$
                     ? Uri.EscapeDataString(s.Substring(MAX_LIMIT*i, MAX_LIMIT))
                     : Uri.EscapeDataString(s.Substring(MAX_LIMIT*i)));
             }
-            return s;
+            return sb.ToString();
         }
 
         public static string UrlEncodeRfc3986(string s)


### PR DESCRIPTION
Fixed: HttpHelper.UrlEncode didn't encode strings, which were longer than 1000 characters.